### PR TITLE
Removed ArgumentNullException for tournament URL on create.

### DIFF
--- a/Challonge.Net/Tournaments/ChallongeClient.cs
+++ b/Challonge.Net/Tournaments/ChallongeClient.cs
@@ -105,12 +105,14 @@ namespace Challonge
             {
                 Dictionary<string, string> parameters = new Dictionary<string, string>
                 {
-                    ["api_key"] = apiKey,
-                    ["tournament[url]"] = url ?? throw new ArgumentNullException("url")
+                    ["api_key"] = apiKey
                 };
 
                 if (name != null)
                     parameters["tournament[name]"] = name;
+                
+                if (url != null)
+                    parameters["tournament[url]"] = url;
 
                 switch (type)
                 {


### PR DESCRIPTION
Per the v1 API spec for [creating tournaments](https://api.challonge.com/v1/documents/tournaments/create):
|Name|Description|
|---|---|
|`tournament[url]`|challonge.com/url (letters, numbers, and underscores only); when blank on create, a random URL will be generated for you|

Null tournament urls should be valid, and not passed as a query parameter (when null) so that the API can return a randomly-generated URL instead.

Not included in this PR, but it might be a valid change as well to remove the requirement for the parameter `url` [here](https://github.com/ErwanTLG/Challonge.Net/blob/master/Challonge.Net/Tournaments/ChallongeClient.cs#L305) and instead make it optional like the rest of the parameters.